### PR TITLE
demonstrate opening with `xarray`

### DIFF
--- a/search-catalog.ipynb
+++ b/search-catalog.ipynb
@@ -137,6 +137,32 @@
    "id": "8",
    "metadata": {},
    "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import fsspec"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs = fsspec.filesystem(\"http\")\n",
+    "dss = [\n",
+    "    xr.open_dataset(fs.open(item.assets[\"https\"].href), engine=\"h5netcdf\").load()\n",
+    "    for item in filtered\n",
+    "]\n",
+    "dss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],


### PR DESCRIPTION
`xpystac` doesn't support opening netcdf files, yet, so we can't use that at the moment.